### PR TITLE
Adding missing link to Otters.love in the splash buttons

### DIFF
--- a/Packages/com.killers0992.awtter-space-installer/Editor/Resources/SplashMenuButtons.asset
+++ b/Packages/com.killers0992.awtter-space-installer/Editor/Resources/SplashMenuButtons.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     Image: {fileID: 2800000, guid: 6ad00a3d7db1458468acc3941a4e253a, type: 3}
   - ButtonType: 0
     ButtonText: '  Store'
-    Link: 
+    Link: https://otters.love/
     Image: {fileID: 2800000, guid: 446a7d09a45b13943a049803667788aa, type: 3}
   - ButtonType: 0
     ButtonText: '  Support'

--- a/Packages/com.killers0992.awtter-space-installer/package.json
+++ b/Packages/com.killers0992.awtter-space-installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.killers0992.awtter-space-installer",
   "displayName": "Awtter Space Installer",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "description": "Tool for managing content from AwtterSpace.",
   "unity": "2019.4",
   "vpmDependencies": {},

--- a/Packages/vpm-manifest.json
+++ b/Packages/vpm-manifest.json
@@ -1,25 +1,18 @@
 {
   "dependencies": {
     "com.vrchat.avatars": {
-      "version": "3.8.1"
-    },
-    "com.killers0992.awtter-space-installer": {
-      "version": "1.2.32"
+      "version": "3.8.2"
     }
   },
   "locked": {
     "com.vrchat.avatars": {
-      "version": "3.8.1",
+      "version": "3.8.2",
       "dependencies": {
-        "com.vrchat.base": "3.8.1"
+        "com.vrchat.base": "3.8.2"
       }
     },
     "com.vrchat.base": {
-      "version": "3.8.1",
-      "dependencies": {}
-    },
-    "com.killers0992.awtter-space-installer": {
-      "version": "1.2.32",
+      "version": "3.8.2",
       "dependencies": {}
     }
   }


### PR DESCRIPTION
# 🛠 Pull Request

## ✅ Summary

<!-- Short description of the changes in this PR -->

## 📦 Type of Change

- [x] 🐛 Bugfix
    - Updating splash buttons and adding missing link to otters.love
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🔧 Tooling / maintenance
- [ ] 📄 Documentation
- [ ] 🚑 Hotfix

## 🧪 Testing Steps

<!-- Explain how this was tested (include Unity version, SDK version if relevant) -->
- Unity version:
   1. Open ASI
   2. Click Otters love button at top and make sure Otters.love opens in web browser 

## 🔗 Related Issues / Discussion

<!-- Optional: link related GitHub issues or Discord discussions -->

## 📝 Checklist

- [x] PR includes changelog update
- [x] Version bump if needed (minor)
- [x] Tests passed in Unity

- [ ] Awaiting staff approval in Discord
~~Shared with Beta testers (if applicable)~~

## 🧠 Notes for Reviewers

<!-- Extra context or known limitations -->
